### PR TITLE
GOAWAY発生時に再試行するようにした

### DIFF
--- a/linebot/poll/poll.go
+++ b/linebot/poll/poll.go
@@ -26,6 +26,9 @@ func Poll(ctx context.Context, client *lineclient.LINEClient) {
 	for {
 		operations, err := client.TalkServiceClientForPolling.FetchOps(ctx, localRev, count, globalRev, individualRev)
 		if err != nil {
+			if strings.HasPrefix(err.Error(), "http2: server sent GOAWAY and closed the connection") {
+				continue
+			}
 			log.Fatalf("failed to call fetchOps: %+v\n", err)
 		}
 


### PR DESCRIPTION
該当エラーは `http.http2GoAwayError` と外部パッケージからアクセスできないため